### PR TITLE
feat: implement praxis spec list --from-intent and archive exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.agent/
 node_modules/
 .node_modules/
 built/*

--- a/src/commands/spec/list.test.ts
+++ b/src/commands/spec/list.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { specListAction } from './list.js';
+
+vi.mock('fs');
+
+describe('specListAction', () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+    });
+
+    it('should log a message when no specs directory exists', async () => {
+        vi.mocked(fs.existsSync).mockReturnValue(false);
+
+        await specListAction({});
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('No specifications found'));
+    });
+
+    it('should list all active specs when no intent is specified', async () => {
+        // Setup mock filesystem structure
+        // .praxis/specs/intent1/spec1/spec.md
+        // .praxis/specs/intent1/spec2/spec.md (Archived)
+        // .praxis/specs/intent2/spec3/spec.md
+
+        vi.mocked(fs.readdirSync).mockImplementation((p) => {
+            const pathStr = p.toString();
+            if (pathStr.endsWith('specs')) return ['intent1', 'intent2'] as any;
+            if (pathStr.endsWith('intent1')) return ['spec1', 'spec2'] as any;
+            if (pathStr.endsWith('intent2')) return ['spec3'] as any;
+            return ['spec.md'] as any;
+        });
+
+        vi.mocked(fs.statSync).mockImplementation((p) => {
+            const pathStr = p.toString();
+            return {
+                isDirectory: () => !pathStr.endsWith('spec.md'),
+                isFile: () => pathStr.endsWith('spec.md')
+            } as any;
+        });
+
+        vi.mocked(fs.readFileSync).mockImplementation((p) => {
+            if (p.toString().includes('spec2')) {
+                return '**Status**: Archived\n**Created**: 2024-01-01';
+            }
+            return '**Status**: Draft\n**Created**: 2024-01-01';
+        });
+
+        await specListAction({});
+
+        // Should show spec1 and spec3, but not spec2
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('spec1'));
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('spec3'));
+        expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('spec2'));
+    });
+
+    it('should filter specs by intent ID', async () => {
+        vi.mocked(fs.readdirSync).mockImplementation((p) => {
+            const pathStr = p.toString();
+            if (pathStr.endsWith('specs')) return ['intent1', 'intent2'] as any;
+            if (pathStr.endsWith('intent1')) return ['spec1'] as any;
+            if (pathStr.endsWith('intent2')) return ['spec2'] as any;
+            return ['spec.md'] as any;
+        });
+
+        vi.mocked(fs.statSync).mockImplementation((p) => {
+            const pathStr = p.toString();
+            return {
+                isDirectory: () => !pathStr.endsWith('spec.md'),
+                isFile: () => pathStr.endsWith('spec.md')
+            } as any;
+        });
+
+        vi.mocked(fs.readFileSync).mockReturnValue('**Status**: Draft\n**Created**: 2024-01-01');
+
+        await specListAction({ fromIntent: 'intent1' });
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('spec1'));
+        expect(consoleSpy).not.toHaveBeenCalledWith(expect.stringContaining('spec2'));
+    });
+
+    it('should handle case where no specs match the intent filter', async () => {
+        vi.mocked(fs.readdirSync).mockImplementation((p) => {
+            const pathStr = p.toString();
+            if (pathStr.endsWith('specs')) return ['intent1'] as any;
+            if (pathStr.endsWith('intent1')) return ['spec1'] as any;
+            return ['spec.md'] as any;
+        });
+
+        vi.mocked(fs.statSync).mockImplementation((p) => {
+            const pathStr = p.toString();
+            return {
+                isDirectory: () => !pathStr.endsWith('spec.md'),
+                isFile: () => pathStr.endsWith('spec.md')
+            } as any;
+        });
+
+        vi.mocked(fs.readFileSync).mockReturnValue('**Status**: Draft\n**Created**: 2024-01-01');
+
+        await specListAction({ fromIntent: 'unknown-intent' });
+
+        expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("No active specifications found for intent 'unknown-intent'"));
+    });
+});

--- a/src/commands/spec/list.ts
+++ b/src/commands/spec/list.ts
@@ -1,0 +1,95 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Action for 'praxis spec list'
+ */
+export async function specListAction(options: { fromIntent?: string }) {
+    const rootDir = process.cwd();
+    const specsDir = path.join(rootDir, '.praxis', 'specs');
+
+    if (!fs.existsSync(specsDir)) {
+        console.log('No specifications found (directory .praxis/specs does not exist).');
+        return;
+    }
+
+    const specFiles = findAllSpecFiles(specsDir);
+
+    // Filter by intent if provided
+    let filteredSpecs = specFiles;
+    if (options.fromIntent) {
+        filteredSpecs = specFiles.filter(file => {
+            const intentId = path.basename(path.dirname(path.dirname(file)));
+            return intentId === options.fromIntent;
+        });
+    }
+
+    // Filter out archived specs (both by directory and status)
+    filteredSpecs = filteredSpecs.filter(file => {
+        // Skip if in 'archive' directory
+        if (file.includes(path.sep + 'archive' + path.sep)) {
+            return false;
+        }
+
+        const content = fs.readFileSync(file, 'utf8');
+        const statusMatch = content.match(/\*\*Status\*\*:\s*(.+)/);
+        const status = statusMatch ? statusMatch[1].trim() : '';
+
+        return status.toLowerCase() !== 'archived';
+    });
+
+    if (filteredSpecs.length === 0) {
+        if (options.fromIntent) {
+            console.log(`No active specifications found for intent '${options.fromIntent}'.`);
+        } else {
+            console.log('No active specifications found.');
+        }
+        return;
+    }
+
+    // Print header
+    console.log('%-25s %-25s %-15s %s', 'Intent ID', 'Spec ID', 'Status', 'Created');
+    console.log('-'.repeat(85));
+
+    for (const file of filteredSpecs) {
+        const content = fs.readFileSync(file, 'utf8');
+        const specId = path.basename(path.dirname(file));
+        const intentId = path.basename(path.dirname(path.dirname(file)));
+
+        // Parse metadata using simple regex
+        const statusMatch = content.match(/\*\*Status\*\*:\s*(.+)/);
+        const createdMatch = content.match(/\*\*Created\*\*:\s*(.+)/);
+
+        const status = statusMatch ? statusMatch[1].trim() : 'Unknown';
+        const created = createdMatch ? createdMatch[1].trim() : 'Unknown';
+
+        // Column formatting
+        console.log(`${intentId.padEnd(25)} ${specId.padEnd(25)} ${status.padEnd(15)} ${created}`);
+    }
+}
+
+function findAllSpecFiles(dir: string): string[] {
+    let results: string[] = [];
+    try {
+        const list = fs.readdirSync(dir);
+
+        for (const file of list) {
+            const filePath = path.join(dir, file);
+            const stat = fs.statSync(filePath);
+
+            if (stat.isDirectory()) {
+                // Skip the base archive directory itself to be safe
+                if (path.basename(filePath) === 'archive' && path.dirname(filePath) === dir) {
+                    continue;
+                }
+                results = results.concat(findAllSpecFiles(filePath));
+            } else if (file === 'spec.md') {
+                results.push(filePath);
+            }
+        }
+    } catch (e) {
+        // Ignore errors during traversal
+    }
+
+    return results;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { specDeriveAction } from './commands/spec/derive.js';
 import { specDeleteAction } from './commands/spec/delete.js';
 import { specApplyAction } from './commands/spec/apply.js';
 import { specArchiveAction } from './commands/spec/archive.js';
+import { specListAction } from './commands/spec/list.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packageJsonPath = path.resolve(__dirname, '../package.json');
@@ -68,6 +69,9 @@ manifest.forEach((cmdDef) => {
                 } else if (cmdDef.name === 'spec' && subCmdDef.name === 'archive') {
                     const [specId] = args;
                     await specArchiveAction(specId);
+                } else if (cmdDef.name === 'spec' && subCmdDef.name === 'list') {
+                    const [options] = args;
+                    await specListAction(options);
                 } else {
                     console.log(`Executing ${cmdDef.name} ${subCmdDef.name}...`);
                     // Implementation will go here

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -99,6 +99,13 @@ export const manifest: CommandDefinition[] = [
       {
         name: 'list',
         description: 'List all specifications and their associated intents',
+        options: [
+          {
+            name: 'from-intent',
+            description: 'The ID of the intent to list specs for',
+            required: false,
+          },
+        ],
       },
       {
         name: 'check',


### PR DESCRIPTION
Resolves issue #14.

### Proposed Changes
- Added `--from-intent` argument to `praxis spec list` to filter specifications by intent.
- Implemented automatic exclusion of archived specifications (based on directory and status metadata).
- Registered the new action in `manifest.ts` and `index.ts`.
- Added unit tests to verify filtering and exclusion logic.

### Verification
- Ran `npm test src/commands/spec/list.test.ts` - All 4 tests passed.
- Verified exclusion of specs in `.praxis/specs/archive/` and those with `**Status**: Archived`.
